### PR TITLE
enableColor and consistent width

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -37,7 +37,10 @@
 			"presentation": {
 				"group": "watch"
 			},
-			"problemMatcher": []
+			"isBackground": true,
+			"problemMatcher": [
+				"$tsc-watch"
+			]
 		}
 	]
 }

--- a/src/Logger.spec.ts
+++ b/src/Logger.spec.ts
@@ -73,6 +73,14 @@ describe('Logger', () => {
         expect(child.logLevel).to.eql('warn');
     });
 
+    it('enableColor inherits from parent', () => {
+        const child = logger.createLogger();
+        logger.enableColor = false;
+        expect(child.enableColor).to.eql(false);
+        logger.enableColor = true;
+        expect(child.enableColor).to.eql(true);
+    });
+
     it('parent getter works', () => {
         const child = logger.createLogger();
         expect(child.parent).to.equal(logger);
@@ -321,7 +329,8 @@ describe('Logger', () => {
     });
 
     describe('formatLeadingMessageParts', () => {
-        it('excludes color by default', () => {
+        it(`honors the logger's enableColor setting`, () => {
+            logger.enableColor = false;
             expect(
                 logger.formatLeadingMessageParts(
                     logger.buildLogMessage('error', 'hello world')

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -62,6 +62,26 @@ export class Logger {
     }
 
     /**
+     * If true, colors will be used in transports that support it.
+     */
+    public get enableColor(): boolean {
+        return this.options.enableColor ?? this.options.parent?.enableColor ?? true;
+    }
+    public set enableColor(value: boolean) {
+        this.options.enableColor = value;
+    }
+
+    /**
+     * Should the log level be padded with trailing spaces when printed
+     */
+    public get consistentLogLevelWidth(): boolean {
+        return this.options.consistentLogLevelWidth ?? this.options.parent?.consistentLogLevelWidth ?? false;
+    }
+    public set consistentLogLevelWidth(value: boolean) {
+        this.options.consistentLogLevelWidth = value;
+    }
+
+    /**
     * Get notified about every log message
     * @param subscriber a function that is called with the given log message
     * @returns an unsubscribe function
@@ -156,9 +176,12 @@ export class Logger {
      * Get all the leading parts of the message. This includes timestamp, log level, any message prefixes.
      * This excludes actual body of the messages.
      */
-    public formatLeadingMessageParts(message: LogMessage, enableColor = false) {
+    public formatLeadingMessageParts(message: LogMessage, enableColor = this.enableColor) {
         let timestampText = '[' + message.timestamp + ']';
         let logLevelText = message.logLevel.toUpperCase();
+        if (this.consistentLogLevelWidth) {
+            logLevelText = logLevelText.padEnd(5, ' ');
+        }
         if (enableColor) {
             timestampText = chalk.grey(timestampText);
             const logColorFn = LogLevelColor[message.logLevel] ?? LogLevelColor.log;
@@ -328,6 +351,14 @@ export interface LoggerOptions {
      * A parent logger. Any unspecified options in the current logger will be loaded from the parent.
      */
     parent?: Logger;
+    /**
+     * If true, colors will be used in transports that support it.
+     */
+    enableColor?: boolean;
+    /**
+     * Should the log level be padded with trailing spaces when printed
+     */
+    consistentLogLevelWidth?: boolean;
 }
 
 export interface LogMessage {

--- a/src/transports/ConsoleTransport.ts
+++ b/src/transports/ConsoleTransport.ts
@@ -5,7 +5,7 @@ export class ConsoleTransport {
         const methodName = (console as any)[message.logLevel] ? message.logLevel : 'log';
 
         (console as any)[methodName](
-            message.logger.formatLeadingMessageParts(message, true),
+            message.logger.formatLeadingMessageParts(message),
             ...message.args
         );
     }


### PR DESCRIPTION
- add `enableColor` option - for enabling/disabling colors, which can be inherited through the logger chain.
- adds `consistentLogLevelWidth` option - for enforcing that all logLevel printed text are the same width.