### PR TITLE
Fix crash when encountering bigint

### DIFF
--- a/src/Logger.spec.ts
+++ b/src/Logger.spec.ts
@@ -22,6 +22,16 @@ describe('Logger', () => {
         sinon.restore();
     });
 
+    it('does not crash on bigint', () => {
+        logger = new Logger();
+        //should not throw
+        expect(
+            logger['buildLogMessage']('debug', {
+                bigNumber: BigInt('123456789123456789')
+            }).argsText
+        ).to.eql('{"bigNumber":"123456789123456789"}');
+    });
+
     it('uses LogLevel.log by default', () => {
         logger = new Logger();
         expect(logger.logLevel).to.eql('log');

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -160,7 +160,10 @@ export class Logger {
                         argsText += (arg as RegExp).toString();
                     } else {
                         argsText += safeJsonStringify(
-                            serializeError(arg)
+                            serializeError(arg),
+                            (_, value) => {
+                                return typeof value === 'bigint' ? value.toString() : value;
+                            }
                         );
                     }
                     break;

--- a/src/transports/ConsoleTransport.ts
+++ b/src/transports/ConsoleTransport.ts
@@ -1,4 +1,4 @@
-import type { LogMessage } from '..';
+import type { LogMessage } from '../Logger';
 
 export class ConsoleTransport {
     pipe(message: LogMessage) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,8 @@
     "exclude": [
         "node_modules",
         "src/**/*.spec.ts"
-    ]
+    ],
+    "ts-node": {
+        "transpileOnly": true
+    }
 }


### PR DESCRIPTION
Fix crash when serializing objects that contain `BigInt` property values