### PR TITLE
Security Audit workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
           node-version: "18.20.4"
           architecture: 'x64' # fix for macos-latest
       - run: npm ci
-      - run: npm run audit
       - run: npm run build
       - run: npm run lint
       - run: npm run test

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
   pull_request:
+  schedule:
+    #nightly at 00:00 UTC
+    - cron: '0 0 * * *'
 
 jobs:
   audit:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,17 @@
+name: Security Audit
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          node-version: "18.20.4"
+      - run: npm ci
+      - run: npm run audit

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -5,8 +5,8 @@ on:
       - master
   pull_request:
   schedule:
-    #nightly at 00:00 UTC
-    - cron: '0 0 * * *'
+    #nightly at 06:00 UTC (1am EST / 2am EDT)
+    - cron: '0 6 * * *'
 
 jobs:
   audit:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A node.js logger library for use in the RokuCommunity projects.
 
 [![build status](https://img.shields.io/github/actions/workflow/status/rokucommunity/logger/build.yml?branch=master&logo=github)](https://github.com/rokucommunity/logger/actions/workflows/build.yml?query=branch%3Amaster+workflow%3Abuild)
-[![Security Audit](https://img.shields.io/github/actions/workflow/status/rokucommunity/logger/security-audit.yml?branch=master&logo=github&label=Security%20Audit)](https://github.com/rokucommunity/logger/actions/workflows/security-audit.yml)
+[![security](https://img.shields.io/github/actions/workflow/status/rokucommunity/logger/security-audit.yml?branch=master&label=security&logo=data:image/svg%2Bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI+PHJlY3QgeD0iMyIgeT0iOCIgd2lkdGg9IjEwIiBoZWlnaHQ9IjciIHJ4PSIxIiBmaWxsPSJ3aGl0ZSIvPjxwYXRoIGQ9Ik01IDhWNWEzIDMgMCAwIDEgNiAwdjMiIGZpbGw9Im5vbmUiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMiIvPjwvc3ZnPg==)](https://github.com/rokucommunity/logger/actions/workflows/security-audit.yml)
 [![coverage status](https://img.shields.io/coveralls/github/rokucommunity/logger?logo=coveralls)](https://coveralls.io/github/rokucommunity/logger?branch=master)
 [![monthly downloads](https://img.shields.io/npm/dm/@rokucommunity/logger.svg?sanitize=true&logo=npm&logoColor=)](https://npmcharts.com/compare/@rokucommunity/logger?minimal=true)
 [![npm version](https://img.shields.io/npm/v/@rokucommunity/logger.svg?logo=npm)](https://www.npmjs.com/package/@rokucommunity/logger)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A node.js logger library for use in the RokuCommunity projects.
 
 [![build status](https://img.shields.io/github/actions/workflow/status/rokucommunity/logger/build.yml?branch=master&logo=github)](https://github.com/rokucommunity/logger/actions/workflows/build.yml?query=branch%3Amaster+workflow%3Abuild)
+[![Security Audit](https://img.shields.io/github/actions/workflow/status/rokucommunity/logger/security-audit.yml?branch=master&logo=github)](https://github.com/rokucommunity/logger/actions/workflows/security-audit.yml)
 [![coverage status](https://img.shields.io/coveralls/github/rokucommunity/logger?logo=coveralls)](https://coveralls.io/github/rokucommunity/logger?branch=master)
 [![monthly downloads](https://img.shields.io/npm/dm/@rokucommunity/logger.svg?sanitize=true&logo=npm&logoColor=)](https://npmcharts.com/compare/@rokucommunity/logger?minimal=true)
 [![npm version](https://img.shields.io/npm/v/@rokucommunity/logger.svg?logo=npm)](https://www.npmjs.com/package/@rokucommunity/logger)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A node.js logger library for use in the RokuCommunity projects.
 
 [![build status](https://img.shields.io/github/actions/workflow/status/rokucommunity/logger/build.yml?branch=master&logo=github)](https://github.com/rokucommunity/logger/actions/workflows/build.yml?query=branch%3Amaster+workflow%3Abuild)
-[![Security Audit](https://img.shields.io/github/actions/workflow/status/rokucommunity/logger/security-audit.yml?branch=master&logo=github)](https://github.com/rokucommunity/logger/actions/workflows/security-audit.yml)
+[![Security Audit](https://img.shields.io/github/actions/workflow/status/rokucommunity/logger/security-audit.yml?branch=master&logo=github&label=Security%20Audit)](https://github.com/rokucommunity/logger/actions/workflows/security-audit.yml)
 [![coverage status](https://img.shields.io/coveralls/github/rokucommunity/logger?logo=coveralls)](https://coveralls.io/github/rokucommunity/logger?branch=master)
 [![monthly downloads](https://img.shields.io/npm/dm/@rokucommunity/logger.svg?sanitize=true&logo=npm&logoColor=)](https://npmcharts.com/compare/@rokucommunity/logger?minimal=true)
 [![npm version](https://img.shields.io/npm/v/@rokucommunity/logger.svg?logo=npm)](https://www.npmjs.com/package/@rokucommunity/logger)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A node.js logger library for use in the RokuCommunity projects.
 [![build status](https://img.shields.io/github/actions/workflow/status/rokucommunity/logger/build.yml?branch=master&logo=github)](https://github.com/rokucommunity/logger/actions/workflows/build.yml?query=branch%3Amaster+workflow%3Abuild)
 [![security](https://img.shields.io/github/actions/workflow/status/rokucommunity/logger/security-audit.yml?branch=master&label=security&logo=data:image/svg%2Bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI+PHJlY3QgeD0iMyIgeT0iOCIgd2lkdGg9IjEwIiBoZWlnaHQ9IjciIHJ4PSIxIiBmaWxsPSJ3aGl0ZSIvPjxwYXRoIGQ9Ik01IDhWNWEzIDMgMCAwIDEgNiAwdjMiIGZpbGw9Im5vbmUiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMiIvPjwvc3ZnPg==)](https://github.com/rokucommunity/logger/actions/workflows/security-audit.yml)
 [![coverage status](https://img.shields.io/coveralls/github/rokucommunity/logger?logo=coveralls)](https://coveralls.io/github/rokucommunity/logger?branch=master)
-[![monthly downloads](https://img.shields.io/npm/dm/@rokucommunity/logger.svg?sanitize=true&logo=npm&logoColor=)](https://npmcharts.com/compare/@rokucommunity/logger?minimal=true)
-[![npm version](https://img.shields.io/npm/v/@rokucommunity/logger.svg?logo=npm)](https://www.npmjs.com/package/@rokucommunity/logger)
+[![monthly downloads](https://img.shields.io/npm/dm/@rokucommunity/logger.svg?sanitize=true&logo=npm&logoColor=&label=npm)](https://npmcharts.com/compare/@rokucommunity/logger?minimal=true)
+[![npm version](https://img.shields.io/npm/v/@rokucommunity/logger.svg?logo=npm&label=npm)](https://www.npmjs.com/package/@rokucommunity/logger)
 [![license](https://img.shields.io/github/license/rokucommunity/logger.svg)](LICENSE)
 [![Slack](https://img.shields.io/badge/Slack-RokuCommunity-4A154B?logo=slack)](https://join.slack.com/t/rokudevelopers/shared_invite/zt-4vw7rg6v-NH46oY7hTktpRIBM_zGvwA)
 


### PR DESCRIPTION
Adds a dedicated `Security Audit` GitHub Actions workflow that runs `npm run audit` on PRs and master pushes. The job is single-OS (ubuntu-latest, node 18.20.4) so the status check is fast and self-contained. Also removes the redundant `npm run audit` step from `build.yml`.